### PR TITLE
adds profile property by default and ignores .idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.pid
 *.gz
 
+.idea
+
 npm-debug.log
 node_modules
 

--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,6 @@
 {
 	"Amazon" : {
 		"lambda-arn" : "YOUR ARN HERE",
+		"profile": ""
 	}
 }


### PR DESCRIPTION
Should fix #2.  Just adds the profile property by default since it seems you can't deploy without it.
